### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -6,6 +6,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/2](https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific permissions. Based on the workflow's operations, the minimal required permissions are `contents: read`. This ensures the workflow can read repository contents without granting unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
