### PR TITLE
Potential fix for code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/plugin/controllers/file.py
+++ b/plugin/controllers/file.py
@@ -70,8 +70,11 @@ class FileController(resource.Resource):
 				if m is not None:
 					port = m.group(1)
 
-				response = "#EXTM3U\n#EXTVLCOPT:http-reconnect=true\n#EXTINF:-1,%s\n%s://%s:%s/file?action=download&file=%s" % (name, proto, request.getRequestHostname(), port, quote(filename))
-				request.setHeader("Content-Disposition", 'attachment;filename="%s.m3u"' % name)
+				from html import escape
+				escaped_name = escape(name)
+				escaped_hostname = escape(request.getRequestHostname().decode('ascii'))
+				response = "#EXTM3U\n#EXTVLCOPT:http-reconnect=true\n#EXTINF:-1,%s\n%s://%s:%s/file?action=download&file=%s" % (escaped_name, proto, escaped_hostname, port, quote(filename))
+				request.setHeader("Content-Disposition", 'attachment;filename="%s.m3u"' % escaped_name)
 				request.setHeader("Content-Type", "application/x-mpegurl")
 				return response
 			elif action == "delete":


### PR DESCRIPTION
Potential fix for [https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/5](https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/5)

To fix the issue, all user-provided values interpolated into the `response` string should be properly escaped to prevent XSS vulnerabilities. Specifically:
1. Use `html.escape()` from Python's standard library to escape `name` and `request.getRequestHostname()` before including them in the `response`.
2. Ensure that all user-provided input is sanitized or escaped before being used in the response.

The changes will be made in the `render` method of the `FileController` class, specifically in the block where the `response` variable is constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
