### PR TITLE
Potential fix for code scanning alert no. 54: Unsafe jQuery plugin

### DIFF
--- a/sourcefiles/modern/plugins/bootstrap/js/bootstrap.js
+++ b/sourcefiles/modern/plugins/bootstrap/js/bootstrap.js
@@ -2217,7 +2217,10 @@ if (typeof jQuery === 'undefined') {
   var Affix = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
-    this.$target = $(this.options.target)
+    if (typeof this.options.target !== 'string' || !/^[#.]?[\w-]+$/.test(this.options.target)) {
+      throw new Error('Affix target must be a valid CSS selector string');
+    }
+    this.$target = jQuery.find(this.options.target)
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 


### PR DESCRIPTION
Potential fix for [https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/54](https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/54)

To fix the issue, we need to ensure that the `target` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `$()` function when interpreting the `target` option. Additionally, we should validate the `target` option to ensure it is a string and does not contain potentially unsafe characters.

The changes will be made in the `Affix` constructor (line 2217) where `this.options.target` is used. Specifically:
1. Replace the use of `$()` with `jQuery.find` to ensure the `target` is treated as a CSS selector.
2. Add validation to ensure the `target` option is a valid string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
