### PR TITLE
Potential fix for code scanning alert no. 51: DOM text reinterpreted as HTML

### DIFF
--- a/sourcefiles/modern/plugins/materialize-css/js/materialize.js
+++ b/sourcefiles/modern/plugins/materialize-css/js/materialize.js
@@ -5153,7 +5153,7 @@ function PickerConstructor( ELEMENT, NAME, COMPONENT, OPTIONS ) {
             // If the element has a value, set the hidden value as well.
             (
                 $ELEMENT.data('value') || ELEMENT.value ?
-                    ' value="' + P.get('select', SETTINGS.formatSubmit) + '"' :
+                    ' value="' + DOMPurify.sanitize(P.get('select', SETTINGS.formatSubmit)) + '"' :
                     ''
             ) +
             '>'


### PR DESCRIPTION
Potential fix for [https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/51](https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/51)

To fix the issue, the data used to construct the HTML string should be sanitized or escaped to ensure that it cannot be interpreted as executable HTML or JavaScript. The best approach is to use `DOMPurify` to sanitize the data before concatenating it into the HTML string. This ensures that any potentially malicious content is neutralized.

The fix involves:
1. Using `DOMPurify.sanitize` to sanitize the value returned by `P.get('select', SETTINGS.formatSubmit)` before it is used in the HTML string.
2. Ensuring that all dynamic data concatenated into the HTML string is sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
