### PR TITLE
Potential fix for code scanning alert no. 50: DOM text reinterpreted as HTML

### DIFF
--- a/sourcefiles/modern/plugins/materialize-css/js/materialize.js
+++ b/sourcefiles/modern/plugins/materialize-css/js/materialize.js
@@ -3026,9 +3026,9 @@ $(document).ready(function(){
             var img = $el.find('img');
             var matchStart = $el.text().toLowerCase().indexOf("" + string.toLowerCase() + ""),
                 matchEnd = matchStart + string.length - 1,
-                beforeMatch = $el.text().slice(0, matchStart),
-                matchText = $el.text().slice(matchStart, matchEnd + 1),
-                afterMatch = $el.text().slice(matchEnd + 1);
+                beforeMatch = DOMPurify.sanitize($el.text().slice(0, matchStart)),
+                matchText = DOMPurify.sanitize($el.text().slice(matchStart, matchEnd + 1)),
+                afterMatch = DOMPurify.sanitize($el.text().slice(matchEnd + 1));
             $el.html("<span>" + beforeMatch + "<span class='highlight'>" + matchText + "</span>" + afterMatch + "</span>");
             if (img.length) {
               $el.prepend(img);


### PR DESCRIPTION
Potential fix for [https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/50](https://github.com/kueken/e2openplugin-OpenWebif/security/code-scanning/50)

To fix the issue, the DOM text extracted via `$el.text()` should be properly escaped before being inserted into the HTML string. This ensures that any meta-characters in the text are treated as plain text rather than HTML. A library like `DOMPurify` or a built-in escaping function can be used for this purpose.

**Steps to fix:**
1. Use `DOMPurify.sanitize` or a similar escaping mechanism to sanitize `beforeMatch`, `matchText`, and `afterMatch` before concatenating them into the HTML string.
2. Replace the vulnerable line (3032) with a version that ensures all text is escaped before being inserted into the DOM.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
